### PR TITLE
chore: remove unused submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,3 @@
 	path = yacd
 	url = https://github.com/haishanh/yacd
 	branch = gh-pages
-
-[submodule "usdpl"]
-	path = src/usdpl
-	url = https://github.com/NGnius/usdpl-rs
-	branch = main


### PR DESCRIPTION
Since we are using `wget` to download this dependency from our release assets, this submodule can be removed.

https://github.com/YukiCoco/ToMoon/blob/80b1632fe102cddb528dad0931d4399843f60fd2/.github/workflows/build.yml#L18-L31