### PR TITLE
feat: use global decky-frontend-lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@rollup/plugin-typescript": "^8.5.0",
     "@types/react": "16.14.0",
     "@types/webpack": "^5.28.0",
+    "decky-frontend-lib": "^3.24.5",
     "rollup": "^2.79.1",
     "rollup-plugin-import-assets": "^1.1.1",
     "shx": "^0.3.4",
@@ -40,7 +41,6 @@
   },
   "dependencies": {
     "axios": "^1.2.2",
-    "decky-frontend-lib": "^3.24.5",
     "qrcode.react": "^3.1.0",
     "react-icons": "^4.6.0",
     "usdpl-front": "file:src/usdpl"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,16 +1,9 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 dependencies:
   axios:
     specifier: ^1.2.2
     version: 1.2.2
-  decky-frontend-lib:
-    specifier: ^3.24.5
-    version: 3.24.5
   qrcode.react:
     specifier: ^3.1.0
     version: 3.1.0
@@ -43,6 +36,9 @@ devDependencies:
   '@types/webpack':
     specifier: ^5.28.0
     version: 5.28.0
+  decky-frontend-lib:
+    specifier: ^3.24.5
+    version: 3.24.5
   rollup:
     specifier: ^2.79.1
     version: 2.79.1
@@ -466,7 +462,7 @@ packages:
 
   /decky-frontend-lib@3.24.5:
     resolution: {integrity: sha512-eYlbKDOOcIBPI0b76Rqvlryq2ym/QNiry4xf2pFrXmBa1f95dflqbQAb2gTq9uHEa5gFmeV4lUcMPGJ3M14Xqw==}
-    dev: false
+    dev: true
 
   /deepmerge@4.2.2:
     resolution: {integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==}
@@ -1008,4 +1004,9 @@ packages:
   file:src/usdpl:
     resolution: {directory: src/usdpl, type: directory}
     name: usdpl-front
+    version: 0.7.0
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,12 +24,13 @@ export default defineConfig({
     })
   ],
   context: 'window',
-  external: ['react', 'react-dom'],
+  external: ['react', 'react-dom', 'decky-frontend-lib'],
   output: {
     file: 'dist/index.js',
     globals: {
       react: 'SP_REACT',
       'react-dom': 'SP_REACTDOM',
+      'decky-frontend-lib': 'DFL',
     },
     format: 'iife',
     exports: 'default',


### PR DESCRIPTION
不再需要更新decky-frontend-lib作为依赖，直接使用decky中的decky-frontend-lib。