### PR TITLE
feat: Use the decky data dir as the working path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
           wget -O clash.gz https://github.com/MetaCubeX/mihomo/releases/download/v1.18.3/mihomo-linux-amd64-v1.18.3.gz
           gzip -d clash.gz
           # country.mmdb & geosite.dat
+          wget https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geoip.metadb
           wget https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/country.mmdb
           wget https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geosite.dat
           wget -O asn.mmdb https://github.com/P3TERX/GeoLite.mmdb/raw/download/GeoLite2-ASN.mmdb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,8 @@ jobs:
           cp -r ./tomoon-web/dist ./release/tomoon/web
           cp -r ./py_modules ./release/tomoon/py_modules
           cd ./release 
-          zip -r tomoon-${{ github.ref_name }}.zip tomoon
+          ref=$(echo ${{ github.ref_name }} | sed 's/\//-/g')
+          zip -r tomoon-${ref}.zip tomoon
           cd ..
 
       - name: Publish Artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,20 +1,21 @@
+name: ToMoon Auto Build
+
 on:
   - push
   - pull_request
 
-name: ToMoon Auto Build
+permissions:
+  contents: write
 
 jobs:
-  linux_amd64:
-    name: Linux AMD64
+  build_plugin:
+    name: Build Plugin
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       #build tomoon start
       - uses: actions/checkout@v4
-      - name: Set env
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Download Clash and Yacd
         run: |
@@ -57,26 +58,8 @@ jobs:
           directory: ./backend
           args: --target x86_64-unknown-linux-gnu --release
           use-cross: false
-      # build backend end
-      #build tomoon stop
-      #output: # ToMoon/backend/target/x86_64-unknown-linux-gnu/release/tomoon
 
-      # - uses: actions-rs/toolchain@v1
-      #   with:
-      #     toolchain: stable
-      #     target: x86_64-unknown-linux-gnu
-      #     override: true
-      # - uses: actions-rs/cargo@v1
-      #   with:
-      #     use-cross: true
-      #     command: build
-      #     args: --target x86_64-unknown-linux-gnu --release # ToMoon/backend/target/x86_64-unknown-linux-gnu/release/tomoon
-      # - uses: actions/setup-node@v3
-      #   with:
-      #     node-version: 16
-      # - run: pnpm run build
       - name: Collect Files
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         run: |
           mkdir -p ./release/tomoon/bin/core/web
           mkdir -p ./release/tomoon/dist
@@ -89,30 +72,39 @@ jobs:
           cp -r ./tomoon-web/dist ./release/tomoon/web
           cp -r ./py_modules ./release/tomoon/py_modules
           cd ./release 
-          zip -r tomoon-${{ env.RELEASE_VERSION }}.zip tomoon
+          zip -r tomoon.zip tomoon
           cd ..
 
-      - name: Create Release
-        id: create-release
-        uses: actions/create-release@v1
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish Artifacts
+        uses: actions/upload-artifact@v4
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          #body_path: Changelog/${{ env.RELEASE_VERSION }}-changelog.md
-          draft: false
-          prerelease: false
+          name: tomoon-artifacts
+          path: ./release/tomoon.zip
+          if-no-files-found: error
 
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+
+  publish:
+    name: Publish Release
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    needs: build_plugin
+    steps:
+      - run: mkdir /tmp/artifacts
+
+      - name: download artifact
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/artifacts
+
+      - run: ls -R /tmp/artifacts
+
+      - name: publish to github release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: /tmp/artifacts/tomoon-artifacts/tomoon.zip
+          name: Release ${{ github.ref_name }}
+          draft: false
+          generate_release_notes: true
+          prerelease: contains(github.ref, 'pre')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./release/tomoon-${{ env.RELEASE_VERSION }}.zip
-          asset_name: tomoon-${{ env.RELEASE_VERSION }}.zip
-          asset_content_type: application/zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,15 +73,14 @@ jobs:
           cp -r ./tomoon-web/dist ./release/tomoon/web
           cp -r ./py_modules ./release/tomoon/py_modules
           cd ./release 
-          ref=$(echo ${{ github.ref_name }} | sed 's/\//-/g')
-          zip -r tomoon-${ref}.zip tomoon
+          zip -r tomoon.zip tomoon
           cd ..
 
       - name: Publish Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: tomoon-artifacts
-          path: ./release/tomoon*.zip
+          path: ./release/tomoon.zip
           if-no-files-found: error
 
 
@@ -99,6 +98,10 @@ jobs:
           path: /tmp/artifacts
 
       - run: ls -R /tmp/artifacts
+      - run: |
+          mv /tmp/artifacts/tomoon-artifacts/tomoon.zip /tmp/artifacts/tomoon-artifacts/tomoon-$GITHUB_REF_NAME.zip
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
 
       - name: publish to github release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,6 @@ jobs:
           wget -O clash.gz https://github.com/MetaCubeX/mihomo/releases/download/v1.18.3/mihomo-linux-amd64-v1.18.3.gz
           gzip -d clash.gz
           # country.mmdb & geosite.dat
-          wget https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geoip.metadb
           wget https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/country.mmdb
           wget https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geosite.dat
           wget -O asn.mmdb https://github.com/P3TERX/GeoLite.mmdb/raw/download/GeoLite2-ASN.mmdb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,14 +72,14 @@ jobs:
           cp -r ./tomoon-web/dist ./release/tomoon/web
           cp -r ./py_modules ./release/tomoon/py_modules
           cd ./release 
-          zip -r tomoon.zip tomoon
+          zip -r tomoon-${{ github.ref_name }}.zip tomoon
           cd ..
 
       - name: Publish Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: tomoon-artifacts
-          path: ./release/tomoon.zip
+          path: ./release/tomoon*.zip
           if-no-files-found: error
 
 
@@ -101,7 +101,7 @@ jobs:
       - name: publish to github release
         uses: softprops/action-gh-release@v2
         with:
-          files: /tmp/artifacts/tomoon-artifacts/tomoon.zip
+          files: /tmp/artifacts/tomoon-artifacts/tomoon*.zip
           name: Release ${{ github.ref_name }}
           draft: false
           generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ release
 
 clash
 .history
+web

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,1 @@
-[submodule "yacd"]
-	path = yacd
-	url = https://github.com/haishanh/yacd
-	branch = gh-pages
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,161 @@
+ifneq (,$(wildcard ./.env))
+	include .env
+	export
+endif
+
+SHELL=bash
+
+help: ## Display list of tasks with descriptions
+	@echo "+ $@"
+	@fgrep -h ": ## " $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed 's/-default//' | awk 'BEGIN {FS = ": ## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+vendor: ## Install project dependencies
+	@echo "+ $@"
+	@pnpm i
+
+env: ## Create default .env file
+	@echo "+ $@"
+	@echo -e '# Makefile tools\nDECK_USER=deck\nDECK_HOST=\nDECK_PORT=22\nDECK_HOME=/home/deck\nDECK_KEY=~/.ssh/id_rsa' >> .env
+	@echo -n "PLUGIN_FOLDER=" >> .env
+	@jq -r .name package.json >> .env
+
+init: ## Initialize project
+	@$(MAKE) env
+	@$(MAKE) vendor
+	@echo -e "\n\033[1;36m Almost ready! Just a few things left to do:\033[0m\n"
+	@echo -e "1. Open .env file and make sure every DECK_* variable matches your steamdeck's ip/host, user, etc"
+	@echo -e "2. Run \`\033[0;36mmake copy-ssh-key\033[0m\` to copy your public ssh key to steamdeck"
+	@echo -e "3. Build your code with \`\033[0;36mmake build\033[0m\` or \`\033[0;36mmake docker-build\033[0m\` to build inside a docker container"
+	@echo -e "4. Deploy your plugin code to steamdeck with \`\033[0;36mmake deploy\033[0m\`"
+
+update-frontend-lib: ## Update decky-frontend-lib
+	@echo "+ $@"
+	@pnpm update decky-frontend-lib --latest
+
+download:
+	@echo "+ $@"
+	@$(MAKE) clean_tmp
+	@$(MAKE) download_core
+	@$(MAKE) download_mmdb
+	@$(MAKE) download_yacd
+
+clean_tmp:
+	@echo "+ $@"
+	@rm -rf ./tmp/*
+
+download_core:
+	@echo "+ $@"
+	@mkdir -p ./tmp
+	@mkdir -p ./tmp/core
+	@wget -O clash.gz https://github.com/MetaCubeX/mihomo/releases/download/v1.18.3/mihomo-linux-amd64-v1.18.3.gz
+	@gzip -d clash.gz -c > ./tmp/core/clash
+	@rm -f clash.gz
+
+download_mmdb:
+	@echo "+ $@"
+	@mkdir -p ./tmp
+	@mkdir -p ./tmp/core
+	@wget -O ./tmp/core/country.mmdb https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/country.mmdb
+	@wget -O ./tmp/core/geosite.dat https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geosite.dat
+	@wget -O ./tmp/core/asn.mmdb https://github.com/P3TERX/GeoLite.mmdb/raw/download/GeoLite2-ASN.mmdb
+
+download_yacd:
+	@echo "+ $@"
+	@mkdir -p ./tmp
+	@mkdir -p ./tmp/core
+	@wget -O ./tmp/yacd.zip https://github.com/MetaCubeX/yacd/archive/gh-pages.zip
+	@unzip ./tmp/yacd.zip -d ./tmp
+	@mv ./tmp/Yacd-meta-gh-pages ./tmp/core/web
+	@rm -f ./tmp/yacd.zip
+
+
+build-front: ## Build frontend
+	@echo "+ $@"
+	@pnpm run build
+	@$(MAKE) build-front-sub
+	@$(MAKE) copy-file
+
+build-front-sub:
+	@echo "+ $@"
+	@pnpm --prefix ./tomoon-web run build
+	@mkdir -p ./web
+	@cp -r ./tomoon-web/dist/* ./web
+
+copy-file:
+	@echo "+ $@"
+	@cp -r ./tmp/core ./bin/
+
+build-back: ## Build backend
+	@echo "+ $@"
+	@make -C ./backend
+
+build: ## Build everything
+	@$(MAKE) build-front build-back
+
+copy-ssh-key: ## Copy public ssh key to steamdeck
+	@echo "+ $@"
+	@ssh-copy-id -i $(DECK_KEY) $(DECK_USER)@$(DECK_HOST)
+
+deploy-steamdeck: ## Deploy plugin build to steamdeck
+	@echo "+ $@"
+	@ssh $(DECK_USER)@$(DECK_HOST) -p $(DECK_PORT) -i $(DECK_KEY) \
+ 		'chmod -v 755 $(DECK_HOME)/homebrew/plugins/ && mkdir -p $(DECK_HOME)/homebrew/plugins/$(PLUGIN_FOLDER)'
+	@rsync -azp --delete --progress -e "ssh -p $(DECK_PORT) -i $(DECK_KEY)" \
+		--chmod=Du=rwx,Dg=rx,Do=rx,Fu=rwx,Fg=rx,Fo=rx \
+		--exclude='.git/' \
+		--exclude='.github/' \
+		--exclude='.vscode/' \
+		--exclude='node_modules/' \
+		--exclude='.pnpm-store/' \
+		--exclude='src/' \
+		--exclude='yacd' . \
+		--exclude='tomoon-web/' \
+		--exclude='backend/' \
+		--exclude='tmp/' \
+		--exclude='*.log' \
+		--exclude='.gitignore' . \
+		--exclude='.idea' . \
+		--exclude='.env' . \
+		--exclude='Makefile' . \
+		--exclude='usdpl/' \
+		--exclude='assets/' \
+ 		./ $(DECK_USER)@$(DECK_HOST):$(DECK_HOME)/homebrew/plugins/$(PLUGIN_FOLDER)/
+	@ssh $(DECK_USER)@$(DECK_HOST) -p $(DECK_PORT) -i $(DECK_KEY) \
+ 		'chmod -v 755 $(DECK_HOME)/homebrew/plugins/'
+
+restart-decky: ## Restart Decky on remote steamdeck
+	@echo "+ $@"
+	@ssh -t $(DECK_USER)@$(DECK_HOST) -p $(DECK_PORT) -i $(DECK_KEY) \
+ 		'sudo systemctl restart plugin_loader.service'
+	@echo -e '\033[0;32m+ all is good, restarting Decky...\033[0m'
+
+deploy: ## Deploy code to steamdeck and restart Decky
+	@$(MAKE) deploy-steamdeck
+	@$(MAKE) restart-decky
+
+it: ## Build all code, deploy it to steamdeck, restart Decky
+	@$(MAKE) build deploy
+
+cleanup: ## Delete all generated files and folders
+	@echo "+ $@"
+	@rm -f .env
+	@rm -rf ./dist
+	@rm -rf ./tmp
+	@rm -rf ./node_modules
+	@rm -rf ./.pnpm-store
+	@rm -rf ./backend/out
+
+uninstall-plugin: ## Uninstall plugin from steamdeck, restart Decky
+	@echo "+ $@"
+	@ssh -t $(DECK_USER)@$(DECK_HOST) -p $(DECK_PORT) -i $(DECK_KEY) \
+ 		"sudo sh -c 'rm -rf $(DECK_HOME)/homebrew/plugins/$(PLUGIN_FOLDER)/ && systemctl restart plugin_loader.service'"
+	@echo -e '\033[0;32m+ all is good, restarting Decky...\033[0m'
+
+docker-rebuild-image: ## Rebuild docker image
+	@echo "+ $@"
+	@docker compose build --pull
+
+docker-build: ## Build project inside docker container
+	@$(MAKE) build-back
+	@echo "+ $@"
+	@docker run --rm -i -v $(PWD):/plugin -v $(PWD)/tmp/out:/out ghcr.io/steamdeckhomebrew/builder:latest

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,0 +1,14 @@
+.PHONY: all
+all:
+	@echo "+ $@"
+	@rustup default stable
+	@cross build --release
+	@mkdir -p ../bin
+	@cp ./target/x86_64-unknown-linux-gnu/release/tomoon ../bin/tomoon
+
+
+.PHONY: clean 
+clean:
+	@echo "+ $@"
+	@rm -rf ./target
+	@rm -rf ../bin/tomoon

--- a/backend/build.sh
+++ b/backend/build.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 
+set -e
+rustup default stable
 cross build --release
-cp ./target/x86_64-unknown-linux-gnu/release/clashdeck-rs ../bin/backend
+mkdir -p ../bin
+cp ./target/x86_64-unknown-linux-gnu/release/tomoon ../bin/tomoon

--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -388,6 +388,22 @@ pub fn get_sub_list(runtime: &ControlRuntime) -> impl Fn(Vec<Primitive>) -> Vec<
     }
 }
 
+// get_current_sub 获取当前订阅
+pub fn get_current_sub(runtime: &ControlRuntime) -> impl Fn(Vec<Primitive>) -> Vec<Primitive> {
+    let runtime_setting = runtime.settings_clone();
+    move |_| {
+        match runtime_setting.read() {
+            Ok(x) => {
+                return vec![x.current_sub.clone().into()];
+            }
+            Err(e) => {
+                log::error!("get_current_sub() faild , {}", e);
+            }
+        }
+        return vec![];
+    }
+}
+
 pub fn delete_sub(runtime: &ControlRuntime) -> impl Fn(Vec<Primitive>) -> Vec<Primitive> {
     let runtime_setting = runtime.settings_clone();
     let runtime_state = runtime.state_clone();

--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -83,7 +83,7 @@ pub fn set_clash_status(runtime: &ControlRuntime) -> impl Fn(Vec<Primitive>) -> 
                     }
                 }
                 if *enabled {
-                    match clash.run(&settings.current_sub, settings.skip_proxy, settings.override_dns) {
+                    match clash.run(&settings.current_sub, settings.skip_proxy, settings.override_dns, settings.enhanced_mode) {
                         Ok(_) => (),
                         Err(e) => {
                             log::error!("Run clash error: {}", e);
@@ -353,7 +353,7 @@ pub fn get_running_status(runtime: &ControlRuntime) -> impl Fn(Vec<Primitive>) -
                 return vec![status.into()];
             }
             Err(_) => {
-                log::error!("Error occured while get_download_status()");
+                log::error!("Error occured while get_running_status()");
             }
         }
         return vec![];
@@ -379,7 +379,7 @@ pub fn get_sub_list(runtime: &ControlRuntime) -> impl Fn(Vec<Primitive>) -> Vec<
             }
             Err(e) => {
                 log::error!(
-                    "download_sub() faild to acquire runtime_setting write {}",
+                    "get_sub_list() faild to acquire runtime_setting write {}",
                     e
                 );
             }

--- a/backend/src/control.rs
+++ b/backend/src/control.rs
@@ -289,10 +289,10 @@ impl Clash {
         }
 
         // 检查数据库文件是否存在，不存在则复制
-        if !PathBuf::from(country_db_path).is_file() {
+        if !PathBuf::from(country_db_path.clone()).is_file() {
             match fs::copy(
-                get_current_working_dir().unwrap().join("bin/core/country.mmdb"),
-                decky_data_dir.join("country.mmdb"),
+                new_country_db_path.clone(),
+                country_db_path.clone(),
             ) {
                 Ok(_) => {
                     log::info!("Copy country.mmdb to decky data dir")
@@ -306,10 +306,10 @@ impl Clash {
             }
         }
 
-        if !PathBuf::from(asn_db_path).is_file() {
+        if !PathBuf::from(asn_db_path.clone()).is_file() {
             match fs::copy(
-                get_current_working_dir().unwrap().join("bin/core/asn.mmdb"),
-                decky_data_dir.join("asn.mmdb"),
+                new_asn_db_path.clone(),
+                asn_db_path.clone(),
             ) {
                 Ok(_) => {
                     log::info!("Copy asn.mmdb to decky data dir")
@@ -323,10 +323,10 @@ impl Clash {
             }
         }
         
-        if !PathBuf::from(geosite_path).is_file() {
+        if !PathBuf::from(geosite_path.clone()).is_file() {
             match fs::copy(
-                get_current_working_dir().unwrap().join("bin/core/geosite.dat"),
-                decky_data_dir.join("geosite.dat"),
+                new_geosite_path.clone(),
+                geosite_path.clone(),
             ) {
                 Ok(_) => {
                     log::info!("Copy geosite.dat to decky data dir")
@@ -340,10 +340,10 @@ impl Clash {
             }
         }
 
-        if !PathBuf::from(geoip_path).is_file() {
+        if !PathBuf::from(geoip_path.clone()).is_file() {
             match fs::copy(
-                get_current_working_dir().unwrap().join("bin/core/geoip.metadb"),
-                decky_data_dir.join("geoip.metadb"),
+                new_geoip_path.clone(),
+                geoip_path.clone()
             ) {
                 Ok(_) => {
                     log::info!("Copy geoip.metadb to decky data dir")

--- a/backend/src/control.rs
+++ b/backend/src/control.rs
@@ -275,9 +275,13 @@ impl Clash {
         let new_geosite_path = get_current_working_dir()
             .unwrap()
             .join("bin/core/geosite.dat");
+        let new_geoip_path = get_current_working_dir()
+            .unwrap()
+            .join("bin/core/geoip.metadb");
         let country_db_path = decky_data_dir.join("country.mmdb");
         let asn_db_path = decky_data_dir.join("asn.mmdb");
         let geosite_path = decky_data_dir.join("geosite.dat");
+        let geoip_path = decky_data_dir.join("geoip.metadb");
 
         // 检查 decky_data_dir 是否存在，不存在则创建
         if !decky_data_dir.exists() {
@@ -326,6 +330,23 @@ impl Clash {
             ) {
                 Ok(_) => {
                     log::info!("Copy geosite.dat to decky data dir")
+                },
+                Err(e) => {
+                    return Err(ClashError {
+                        Message: e.to_string(),
+                        ErrorKind: ClashErrorKind::CpDbError,
+                    });
+                }
+            }
+        }
+
+        if !PathBuf::from(geoip_path).is_file() {
+            match fs::copy(
+                get_current_working_dir().unwrap().join("bin/core/geoip.metadb"),
+                decky_data_dir.join("geoip.metadb"),
+            ) {
+                Ok(_) => {
+                    log::info!("Copy geoip.metadb to decky data dir")
                 },
                 Err(e) => {
                     return Err(ClashError {

--- a/backend/src/control.rs
+++ b/backend/src/control.rs
@@ -275,6 +275,9 @@ impl Clash {
         let new_geosite_path = get_current_working_dir()
             .unwrap()
             .join("bin/core/geosite.dat");
+        let country_db_path = decky_data_dir.join("country.mmdb");
+        let asn_db_path = decky_data_dir.join("asn.mmdb");
+        let geosite_path = decky_data_dir.join("geosite.dat");
 
         // 检查 decky_data_dir 是否存在，不存在则创建
         if !decky_data_dir.exists() {
@@ -282,7 +285,7 @@ impl Clash {
         }
 
         // 检查数据库文件是否存在，不存在则复制
-        if !PathBuf::from(new_country_db_path).is_file() {
+        if !PathBuf::from(country_db_path).is_file() {
             match fs::copy(
                 get_current_working_dir().unwrap().join("bin/core/country.mmdb"),
                 decky_data_dir.join("country.mmdb"),
@@ -299,7 +302,7 @@ impl Clash {
             }
         }
 
-        if !PathBuf::from(new_asn_db_path).is_file() {
+        if !PathBuf::from(asn_db_path).is_file() {
             match fs::copy(
                 get_current_working_dir().unwrap().join("bin/core/asn.mmdb"),
                 decky_data_dir.join("asn.mmdb"),
@@ -316,7 +319,7 @@ impl Clash {
             }
         }
         
-        if !PathBuf::from(new_geosite_path).is_file() {
+        if !PathBuf::from(geosite_path).is_file() {
             match fs::copy(
                 get_current_working_dir().unwrap().join("bin/core/geosite.dat"),
                 decky_data_dir.join("geosite.dat"),

--- a/backend/src/control.rs
+++ b/backend/src/control.rs
@@ -281,13 +281,9 @@ impl Clash {
         let new_geosite_path = get_current_working_dir()
             .unwrap()
             .join("bin/core/geosite.dat");
-        let new_geoip_path = get_current_working_dir()
-            .unwrap()
-            .join("bin/core/geoip.metadb");
         let country_db_path = decky_data_dir.join("country.mmdb");
         let asn_db_path = decky_data_dir.join("asn.mmdb");
         let geosite_path = decky_data_dir.join("geosite.dat");
-        let geoip_path = decky_data_dir.join("geoip.metadb");
 
         // 检查 decky_data_dir 是否存在，不存在则创建
         if !decky_data_dir.exists() {
@@ -336,23 +332,6 @@ impl Clash {
             ) {
                 Ok(_) => {
                     log::info!("Copy geosite.dat to decky data dir")
-                },
-                Err(e) => {
-                    return Err(ClashError {
-                        Message: e.to_string(),
-                        ErrorKind: ClashErrorKind::CpDbError,
-                    });
-                }
-            }
-        }
-
-        if !PathBuf::from(geoip_path.clone()).is_file() {
-            match fs::copy(
-                new_geoip_path.clone(),
-                geoip_path.clone()
-            ) {
-                Ok(_) => {
-                    log::info!("Copy geoip.metadb to decky data dir")
                 },
                 Err(e) => {
                     return Err(ClashError {

--- a/backend/src/control.rs
+++ b/backend/src/control.rs
@@ -574,7 +574,7 @@ impl Clash {
                 }
             }
             None => {
-                insert_config(yaml, dns_config_redir_host, "dns");
+                insert_config(yaml, dns_config_fakeip, "dns");
             }
         }
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -89,6 +89,7 @@ async fn main() -> Result<(), std::io::Error> {
             )
             .service(web::resource("/skip_proxy").route(web::post().to(external_web::skip_proxy)))
             .service(web::resource("/override_dns").route(web::post().to(external_web::override_dns)))
+            .service(web::resource("/enhanced_mode").route(web::post().to(external_web::enhanced_mode)))
             .service(web::resource("/get_config").route(web::get().to(external_web::get_config)))
             //.service(web::resource("/manual").route(web::get().to(external_web.web_download_sub)))
             .service(

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -54,6 +54,7 @@ async fn main() -> Result<(), std::io::Error> {
             .register("download_sub", api::download_sub(&runtime))
             .register("get_download_status", api::get_download_status(&runtime))
             .register("get_sub_list", api::get_sub_list(&runtime))
+            .register("get_current_sub", api::get_current_sub(&runtime))
             .register("delete_sub", api::delete_sub(&runtime))
             .register("set_sub", api::set_sub(&runtime))
             .register("update_subs", api::update_subs(&runtime))

--- a/backend/src/settings.rs
+++ b/backend/src/settings.rs
@@ -3,6 +3,8 @@ use std::{path::PathBuf, fmt::Display};
 
 use crate::helper;
 
+use crate::control::EnhancedMode;
+
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Settings {
     #[serde(default = "default_enable")]
@@ -11,6 +13,8 @@ pub struct Settings {
     pub skip_proxy: bool,
     #[serde(default = "default_override_dns")]
     pub override_dns: bool,
+    #[serde(default = "default_enhanced_mode")]
+    pub enhanced_mode: EnhancedMode,
     #[serde(default = "default_current_sub")]
     pub current_sub: String,
     #[serde(default = "default_subscriptions")]
@@ -27,6 +31,10 @@ fn default_enable() -> bool {
 
 fn default_override_dns() -> bool {
     true
+}
+
+fn default_enhanced_mode() -> EnhancedMode {
+    EnhancedMode::RedirHost
 }
 
 fn default_current_sub() -> String {
@@ -122,6 +130,7 @@ impl Default for Settings {
             enable: false,
             skip_proxy: true,
             override_dns: true,
+            enhanced_mode: EnhancedMode::RedirHost,
             current_sub: default_profile.to_string_lossy().to_string(),
             subscriptions: Vec::new()
         }

--- a/backend/src/settings.rs
+++ b/backend/src/settings.rs
@@ -34,7 +34,7 @@ fn default_override_dns() -> bool {
 }
 
 fn default_enhanced_mode() -> EnhancedMode {
-    EnhancedMode::RedirHost
+    EnhancedMode::FakeIp
 }
 
 fn default_current_sub() -> String {
@@ -130,7 +130,7 @@ impl Default for Settings {
             enable: false,
             skip_proxy: true,
             override_dns: true,
-            enhanced_mode: EnhancedMode::RedirHost,
+            enhanced_mode: EnhancedMode::FakeIp,
             current_sub: default_profile.to_string_lossy().to_string(),
             subscriptions: Vec::new()
         }

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -81,6 +81,10 @@ export async function getRunningStatus(): Promise<String> {
   return (await call_backend("get_running_status", []))[0];
 }
 
+export async function getCurrentSub(): Promise<String> {
+  return (await call_backend("get_current_sub", []))[0];
+}
+
 export class PyBackendData {
   private serverAPI: ServerAPI | undefined;
   private current_version = "";

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -81,7 +81,7 @@ export async function getRunningStatus(): Promise<String> {
   return (await call_backend("get_running_status", []))[0];
 }
 
-export async function getCurrentSub(): Promise<String> {
+export async function getCurrentSub(): Promise<string> {
   return (await call_backend("get_current_sub", []))[0];
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,6 +31,7 @@ let enabledOverrideDNS = false;
 let usdplReady = false;
 let subs: any[];
 let subs_option: any[];
+let current_sub = '';
 
 
 const Content: VFC<{ serverAPI: ServerAPI }> = ({ }) => {
@@ -52,15 +53,14 @@ const Content: VFC<{ serverAPI: ServerAPI }> = ({ }) => {
   })
   //setInterval(refreshSubOptions, 2000);
   console.log("status :" + clashState);
-  let [options, setOptions] = useState<DropdownOption[]>(subs_option);
-  // const [selectedOption, setSelectedOption] = useState<number | null>(null);
+  const [options, setOptions] = useState<DropdownOption[]>(subs_option);
   const [optionDropdownDisabled, setOptionDropdownDisabled] = useState(enabledGlobal);
   const [openDashboardDisabled, setOpenDashboardDisabled] = useState(!enabledGlobal);
   const [isSelectionDisabled, setIsSelectionDisabled] = useState(false);
   const [SelectionTips, setSelectionTips] = useState("Run Clash in background");
   const [skipProxyState, setSkipProxyState] = useState(enabledSkipProxy);
   const [overrideDNSState, setOverrideDNSState] = useState(enabledOverrideDNS);
-  const [currentSub, setCurrentSub] = useState<string>("");
+  const [currentSub, setCurrentSub] = useState<string>(current_sub);
 
   const update_subs = () => {
     backend.resolve(backend.getSubList(), (v: String) => {
@@ -84,13 +84,12 @@ const Content: VFC<{ serverAPI: ServerAPI }> = ({ }) => {
         }
       });
       subs_option = items;
+      setOptions(subs_option)
       console.log("Subs ready");
       setIsSelectionDisabled(i == 0);
       //console.log(sub);
     });
   }
-
-  update_subs();
 
   useEffect(() => {
     const getCurrentSub = async () => {
@@ -98,7 +97,12 @@ const Content: VFC<{ serverAPI: ServerAPI }> = ({ }) => {
       setCurrentSub(sub);
     }
     getCurrentSub();
+    update_subs();
   }, []);
+
+  useEffect(() => {
+    current_sub = currentSub;
+  }, [currentSub]);
 
   return (
     <div>
@@ -154,7 +158,7 @@ const Content: VFC<{ serverAPI: ServerAPI }> = ({ }) => {
             selectedOption={currentSub}
             onMenuWillOpen={() => {
               update_subs();
-              setOptions(subs_option);
+              // setOptions(subs_option);
             }}
             onChange={(x) => {
               backend.resolve(backend.setSub(x.data), () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,7 +39,7 @@ let usdplReady = false;
 let subs: any[];
 let subs_option: any[];
 let current_sub = '';
-let enhanced_mode = EnhancedMode.RedirHost;
+let enhanced_mode = EnhancedMode.FakeIp;
 
 const Content: VFC<{ serverAPI: ServerAPI }> = ({ }) => {
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -53,7 +53,7 @@ const Content: VFC<{ serverAPI: ServerAPI }> = ({ }) => {
   //setInterval(refreshSubOptions, 2000);
   console.log("status :" + clashState);
   let [options, setOptions] = useState<DropdownOption[]>(subs_option);
-  const [selectedOption, setSelectedOption] = useState<number | null>(null);
+  // const [selectedOption, setSelectedOption] = useState<number | null>(null);
   const [optionDropdownDisabled, setOptionDropdownDisabled] = useState(enabledGlobal);
   const [openDashboardDisabled, setOpenDashboardDisabled] = useState(!enabledGlobal);
   const [isSelectionDisabled, setIsSelectionDisabled] = useState(false);
@@ -95,9 +95,7 @@ const Content: VFC<{ serverAPI: ServerAPI }> = ({ }) => {
   useEffect(() => {
     const getCurrentSub = async () => {
       const sub = await backend.getCurrentSub();
-      const re = new RegExp("(?<=subs\/).+\.yaml$");
-      const name = re.exec(sub);
-      setCurrentSub(name?.[0] || "");
+      setCurrentSub(sub);
     }
     getCurrentSub();
   }, []);
@@ -151,10 +149,9 @@ const Content: VFC<{ serverAPI: ServerAPI }> = ({ }) => {
         <PanelSectionRow>
           <DropdownItem
             disabled={optionDropdownDisabled}
-            // strDefaultLabel="Select a Subscription"
-            strDefaultLabel={currentSub ? currentSub : "Select a Subscription"}
+            strDefaultLabel={"Select a Subscription"}
             rgOptions={options}
-            selectedOption={selectedOption}
+            selectedOption={currentSub}
             onMenuWillOpen={() => {
               update_subs();
               setOptions(subs_option);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -95,7 +95,9 @@ const Content: VFC<{ serverAPI: ServerAPI }> = ({ }) => {
   useEffect(() => {
     const getCurrentSub = async () => {
       const sub = await backend.getCurrentSub();
-      setCurrentSub(`${sub}`);
+      const re = new RegExp("(?<=subs\/).+\.yaml$");
+      const name = re.exec(sub);
+      setCurrentSub(name?.[0] || "");
     }
     getCurrentSub();
   }, []);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,7 +12,7 @@ import {
   Navigation,
   DropdownItem,
 } from "decky-frontend-lib";
-import { VFC, useState } from "react";
+import { VFC, useEffect, useState } from "react";
 import { GiEgyptianBird } from "react-icons/gi";
 
 import {
@@ -60,9 +60,11 @@ const Content: VFC<{ serverAPI: ServerAPI }> = ({ }) => {
   const [SelectionTips, setSelectionTips] = useState("Run Clash in background");
   const [skipProxyState, setSkipProxyState] = useState(enabledSkipProxy);
   const [overrideDNSState, setOverrideDNSState] = useState(enabledOverrideDNS);
+  const [currentSub, setCurrentSub] = useState<string>("");
 
   const update_subs = () => {
     backend.resolve(backend.getSubList(), (v: String) => {
+      console.log(`getSubList: ${v}`);
       let x: Array<any> = JSON.parse(v.toString());
       let re = new RegExp("(?<=subs\/).+\.yaml$");
       let i = 0;
@@ -89,6 +91,14 @@ const Content: VFC<{ serverAPI: ServerAPI }> = ({ }) => {
   }
 
   update_subs();
+
+  useEffect(() => {
+    const getCurrentSub = async () => {
+      const sub = await backend.getCurrentSub();
+      setCurrentSub(`${sub}`);
+    }
+    getCurrentSub();
+  }, []);
 
   return (
     <div>
@@ -139,7 +149,8 @@ const Content: VFC<{ serverAPI: ServerAPI }> = ({ }) => {
         <PanelSectionRow>
           <DropdownItem
             disabled={optionDropdownDisabled}
-            strDefaultLabel="Select a Subscription"
+            // strDefaultLabel="Select a Subscription"
+            strDefaultLabel={currentSub ? currentSub : "Select a Subscription"}
             rgOptions={options}
             selectedOption={selectedOption}
             onMenuWillOpen={() => {


### PR DESCRIPTION
- 将 clash 的工作路径由 core 改为 decky 插件的 data 路径, 通常为`~/homebrew/data/tomoon`。在更新插件的时候就能保留原有的 ruleset 和 ProxyProviders 等
- 修改 Action 构建脚本，分离构建和发布 Release 步骤，方便测试构建产物
- 在 DropdownItem 中显示当前所选订阅
- 增加 Enhanced Mode 切换，默认 redir-host