### PR TITLE
chores: 一些小改进

### DIFF
--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -506,7 +506,7 @@ pub fn update_subs(runtime: &ControlRuntime) -> impl Fn(Vec<Primitive>) -> Vec<P
                         }
                         thread::spawn(move || {
                             match minreq::get(i.url.clone())
-                            .with_header("User-Agent", format!("ToMoonClash/{}",env!("CARGO_PKG_VERSION")))
+                            .with_header("User-Agent", format!("ToMoon/{} mihomo/1.18.3 Clash/v1.18.0",env!("CARGO_PKG_VERSION")))
                             .with_timeout(15)
                             .send() {
                                 Ok(response) => {
@@ -579,7 +579,8 @@ pub fn create_debug_log() -> impl Fn(Vec<Primitive>) -> Vec<Primitive> {
             "Clash status : {}\n",
             helper::is_clash_running()
         );
-        let tomoon_config = match fs::read_to_string("/home/deck/.config/tomoon/tomoon.json") {
+        let tomoon_config =match fs::read_to_string(
+            usdpl_back::api::dirs::home().unwrap_or("/root".into()).join(".config/tomoon/tomoon.json")) {
             Ok(x) => x,
             Err(e) => {
                 format!("can not get Tomoon config, error message: {} \n", e)
@@ -597,22 +598,6 @@ pub fn create_debug_log() -> impl Fn(Vec<Primitive>) -> Vec<Primitive> {
                 format!("can not get Clash log, error message: {} \n", e)
             }
         };
-        let dns_resolve_config = match fs::read_to_string("/etc/resolv.conf") {
-            Ok(x) => x,
-            Err(e) => {
-                format!("can not get /etc/resolv.conf, error message: {} \n", e)
-            }
-        };
-
-        let network_config = match fs::read_to_string("/etc/NetworkManager/conf.d/dns.conf") {
-            Ok(x) => x,
-            Err(e) => {
-                format!(
-                    "can not get /etc/NetworkManager/conf.d/dns.conf, error message: {} \n",
-                    e
-                )
-            }
-        };
 
         let log = format!(
             "
@@ -623,17 +608,11 @@ pub fn create_debug_log() -> impl Fn(Vec<Primitive>) -> Vec<Primitive> {
         {}\n
         Clash log:\n
         {}\n
-        resolv log:\n
-        {}\n
-        network log:\n
-        {}\n
         ",
             running_status,
             tomoon_config,
             tomoon_log,
             clash_log,
-            dns_resolve_config,
-            network_config
         );
         fs::write("/tmp/tomoon.debug.log", log).unwrap();
         return vec![true.into()];

--- a/backend/src/control.rs
+++ b/backend/src/control.rs
@@ -131,26 +131,6 @@ impl ControlRuntime {
             }
         }
 
-        //保存复原脚本
-        if !Path::new("/home/deck/tomoon_recover.sh").exists() {
-            let recover_script = r#"sudo chattr -i /etc/resolv.conf
-sudo systemctl stop systemd-resolved
-sudo chmod a+w /etc/NetworkManager/conf.d/dns.conf
-sudo echo -e "[main]\ndns=auto"  > /etc/NetworkManager/conf.d/dns.conf
-sudo nmcli general reload"#;
-            match fs::write("/home/deck/tomoon_recover.sh", recover_script) {
-                Ok(_) => {
-                    log::info!("Write recover script to /home/deck/tomoon_recover.sh");
-                }
-                Err(e) => {
-                    log::error!(
-                        "Error occurred while writing recover script, Error msg: {}",
-                        e.to_string()
-                    );
-                }
-            }
-        }
-
         //save config
         thread::spawn(move || {
             let sleep_duration = Duration::from_millis(1000);

--- a/backend/src/external_web.rs
+++ b/backend/src/external_web.rs
@@ -6,7 +6,7 @@ use std::{collections::HashMap, fs, path::PathBuf, sync::Mutex};
 
 use crate::{
     control::{ClashError, ClashErrorKind, EnhancedMode},
-    helper,
+    helper, settings::State,
 };
 
 pub struct Runtime(pub *const crate::control::ControlRuntime);
@@ -274,7 +274,11 @@ pub async fn download_sub(
         runtime_state = runtime.state_clone();
     }
 
-    let path: PathBuf = usdpl_back::api::dirs::home().unwrap_or("/root".into()).join(".config/tomoon/subs/");
+    let home = match runtime_state.read() {
+        Ok(state) => state.home.clone(),
+        Err(_) => State::default().home
+    };
+    let path: PathBuf = home.join(".config/tomoon/subs/");
 
     //是一个本地文件
     if let Some(local_file) = helper::get_file_path(url.clone()) {

--- a/backend/src/external_web.rs
+++ b/backend/src/external_web.rs
@@ -382,7 +382,7 @@ pub async fn download_sub(
         match minreq::get(url.clone())
             .with_header(
                 "User-Agent",
-                format!("ToMoonClash/{}", env!("CARGO_PKG_VERSION")),
+                format!("ToMoon/{} mihomo/1.18.3 Clash/v1.18.0", env!("CARGO_PKG_VERSION")),
             )
             .with_timeout(15)
             .send()

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<(), std::io::Error> {
             .register("set_sub", api::set_sub(&runtime))
             .register("update_subs", api::update_subs(&runtime))
             .register("get_update_status", api::get_update_status(&runtime))
-            .register("create_debug_log", api::create_debug_log())
+            .register("create_debug_log", api::create_debug_log(&runtime))
             .register("get_running_status", api::get_running_status(&runtime))
             .run_blocking()
             .unwrap();


### PR DESCRIPTION
- feat: 现在从本地文件导入的订阅将尽可能采用原有的名字
- feat: 修改 UA 使得能拉取 mihomo 配置文件
- rm: 由于弃用了 smartdns ，删除相关的恢复脚本
- fix!: 改进了获取用户目录的方式，现在所有程序获取的用户目录将是同一个（本更改可能具有破坏性）