### PR TITLE
fix & feat: 修复识别订阅文件名可能出现错误的 bug 以及一些交互优化

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -25,3 +25,4 @@ local-ip-address = "0.5.1"
 actix-cors = "0.6.4"
 tokio = { version = "1.24.1", features = ["macros", "process"]}
 urlencoding = "2.1.3"
+content_disposition = "0.4.0"

--- a/src/pages/Subscriptions.tsx
+++ b/src/pages/Subscriptions.tsx
@@ -127,6 +127,7 @@ export const Subscriptions: FC<SubProp> = ({ Subscriptions }) => {
         <div id="subscription-qrcode">
           <QRCodeCanvas value={QRPageUrl} size={128} />
         </div>
+        <p style={{ textAlign: "center" }}>{QRPageUrl}</p>
         <div id="subscription-download-textfiled" style={cleanPadding}>
           <TextField
             label={localizationManager.getString(L.SUBSCRIPTIONS_LINK)}

--- a/tomoon-web/src/App.jsx
+++ b/tomoon-web/src/App.jsx
@@ -6,7 +6,7 @@ import axios from 'axios'
 
 function App() {
   const [url, setUrl] = useState("");
-  const [isSubscribed, setIsSubscribed] = useState(true);
+  const [isSubscribed, setIsSubscribed] = useState(false);
 
   const handleUrlChange = (event) => {
     setUrl(event.target.value);
@@ -75,18 +75,25 @@ const on_download_btn_click = (url, isSubscribed) => {
         confirmButtonColor: '#5A6242',
         background: '#DEE7BF'
       });
-    }
-  }).catch(error => {
-    if (error.response) {
+    } else {
       Swal.fire({
         icon: 'error',
         iconColor: '#5E5F55',
-        title: '失败',
-        text: error.response.data?.error?.message,
+        title: '后端失败',
+        html: `错误状态: ${response.status}<br>错误信息: ${response.data?.error?.message}`,
         confirmButtonColor: '#5A6242',
         background: '#DEE7BF'
       });
     }
+  }).catch(error => {
+    Swal.fire({
+      icon: 'error',
+      iconColor: '#5E5F55',
+      title: '请求失败',
+      html: `错误类型: ${error.name}<br>错误信息: ${error?.message}`,
+      confirmButtonColor: '#5A6242',
+      background: '#DEE7BF'
+    });
   });
 
 }


### PR DESCRIPTION
* 修复识别订阅文件名可能出现的错误，现在使用 `content_disposition` 模块来处理 content-disposition 头了
* 修复 Web 导入端网络等错误无法展示的问题
* 订阅名称命名现在会在出现冲突的时候按序号命名，在尝试超过 128 号后会返回错误
* 在二维码下方展示链接，方便手动输入